### PR TITLE
Changed tests to not run lintr.

### DIFF
--- a/inst/testdata/.gitignore
+++ b/inst/testdata/.gitignore
@@ -1,1 +1,2 @@
 /.DS_Store
+/prov_console/

--- a/tests/testthat/test_analyzeFunctionReassignments.R
+++ b/tests/testthat/test_analyzeFunctionReassignments.R
@@ -51,7 +51,12 @@ test_that("analyze.function.reassignments - no/empty provenance",
             
             # empty provenance
             c0 <- system.file("testdata", "empty.json", package = "provAnalyzeR")
-            expect_error(prov.analyze.file(c0))
+            
+            # Need to turn the lintr off because it will look for the 
+            # script in the directory specified in the provenance, which 
+            # is an absolute path and won't be found on the computer
+            # where the test is run.
+            expect_error(prov.analyze.file(c0, lintr=FALSE))
             expect_false(provAnalyzeR:::.analyze.env$has.graph)
             expect_error(analyze.function.reassignments())
           })
@@ -64,7 +69,7 @@ test_that("analyze.function.reassignments - no data nodes",
             json <- system.file("testdata", "noDataNodes.json", package = "provAnalyzeR")
             
             provAnalyzeR:::.clear()
-            expect_warning(prov.analyze.file(json))   # warning is due to deleted prov folder
+            expect_warning(prov.analyze.file(json, lintr=FALSE))   # warning is due to deleted prov folder
             
             c2 <- utils::capture.output(c1 <- analyze.function.reassignments())
             
@@ -78,7 +83,7 @@ test_that("analyze.function.reassignments - no variables",
             json <- system.file("testdata", "noVars.json", package = "provAnalyzeR")
             
             provAnalyzeR:::.clear()
-            expect_warning(prov.analyze.file(json))   # warning is due to deleted prov folder
+            expect_warning(prov.analyze.file(json, lintr=FALSE))   # warning is due to deleted prov folder
             
             c2 <- utils::capture.output(c1 <- analyze.function.reassignments())
             
@@ -91,7 +96,7 @@ test_that("analyze.function.reassignments - no variables",
 json <- system.file("testdata", "functionReassignments.json", package = "provAnalyzeR")
 
 provAnalyzeR:::.clear()
-expect_warning(prov.analyze.file(json))   # warning is due to deleted prov folder
+expect_warning(prov.analyze.file(json, lintr=FALSE))   # warning is due to deleted prov folder
 
 expected <- get.expected()
 

--- a/tests/testthat/test_analyzeUtils.R
+++ b/tests/testthat/test_analyzeUtils.R
@@ -8,7 +8,7 @@ context("Utility functions")
 test_that("Utility - .clear", 
           {
             json <- system.file("testdata", "exceptions.json", package = "provAnalyzeR")
-            expect_warning(prov.analyze.file(json))   # warning due to deleted prov folder
+            expect_warning(prov.analyze.file(json, lintr=FALSE))   # warning due to deleted prov folder
             
             # ensure .analyze.env has been changed
             expect_false(is.null(provAnalyzeR:::.analyze.env$prov))
@@ -138,7 +138,7 @@ test_that("Utility - .get.p.id",
             json <- system.file("testdata", "preexisting.json", package = "provAnalyzeR")
             
             provAnalyzeR:::.clear()
-            expect_warning(prov.analyze.file(json))   # warning due to deleted prov folder
+            expect_warning(prov.analyze.file(json, lintr=FALSE))   # warning due to deleted prov folder
             
             # Cases
             c1 <- "d4"    # 1 node found (from output edge only)

--- a/tests/testthat/test_invalidNames.R
+++ b/tests/testthat/test_invalidNames.R
@@ -40,7 +40,7 @@ get.expected <- function()
 json <- system.file("testdata", "invalidNames.json", package = "provAnalyzeR")
 
 provAnalyzeR:::.clear()
-expect_warning(prov.analyze.file(json))   # warning is due to deleted prov folder
+expect_warning(prov.analyze.file(json, lintr=FALSE))   # warning is due to deleted prov folder
 
 expected <- get.expected()
 

--- a/tests/testthat/test_typeChanges.R
+++ b/tests/testthat/test_typeChanges.R
@@ -112,7 +112,7 @@ test_that("analyze.type.changes - no/empty provenance",
             
             # empty provenance
             c0 <- system.file("testdata", "empty.json", package = "provAnalyzeR")
-            expect_error(prov.analyze.file(c0))
+            expect_error(prov.analyze.file(c0, lintr=FALSE))
             expect_false(provAnalyzeR:::.analyze.env$has.graph)
             expect_error(analyze.type.changes())
           })
@@ -125,7 +125,7 @@ test_that("analyze.type.changes - no data nodes",
             json <- system.file("testdata", "noDataNodes.json", package = "provAnalyzeR")
 
             provAnalyzeR:::.clear()
-            expect_warning(prov.analyze.file(json))   # warning is due to deleted prov folder
+            expect_warning(prov.analyze.file(json, lintr=FALSE))   # warning is due to deleted prov folder
 
             c2 <- utils::capture.output(c1 <- analyze.type.changes())
 
@@ -139,7 +139,7 @@ test_that("analyze.type.changes - no variables",
             json <- system.file("testdata", "noVars.json", package = "provAnalyzeR")
 
             provAnalyzeR:::.clear()
-            expect_warning(prov.analyze.file(json))   # warning is due to deleted prov folder
+            expect_warning(prov.analyze.file(json, lintr=FALSE))   # warning is due to deleted prov folder
 
             c2 <- utils::capture.output(c1 <- analyze.type.changes())
 
@@ -151,7 +151,7 @@ test_that("analyze.type.changes - no variables",
 json <- system.file("testdata", "typeChanges.json", package = "provAnalyzeR")
 
 provAnalyzeR:::.clear()
-expect_warning(prov.analyze.file(json))   # warning is due to deleted prov folder
+expect_warning(prov.analyze.file(json, lintr=FALSE))   # warning is due to deleted prov folder
 
 expected <- get.expected()
 


### PR DESCRIPTION
Lintr uses the file name that comes from the json file, which will be
specific to the computer on which the json file was created.